### PR TITLE
ПЛР4.1 P3306 Сорокин Артём

### DIFF
--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -15,7 +15,20 @@ MODULE_DESCRIPTION("A simple FS kernel module");
 
 #define LOG(fmt, ...) pr_info("[" MODULE_NAME "]: " fmt, ##__VA_ARGS__)
 
-static int mask = 0;
+struct vtfs_file {
+  struct list_head list;
+  char* name;
+  ino_t ino;
+  umode_t mode;
+  struct inode* inode;
+  size_t size;
+  char* data;
+};
+
+struct vtfs_dir {
+  struct list_head children;
+  struct vtfs_file* self;
+};
 
 void vtfs_kill_sb(struct super_block*);
 struct dentry* vtfs_mount(struct file_system_type*, int, const char*, void*);
@@ -33,6 +46,7 @@ struct file_operations vtfs_dir_ops = {
 struct inode_operations vtfs_inode_ops = {
     .lookup = vtfs_lookup,
     .create = vtfs_create,
+    .unlink = vtfs_unlink,
 };
 
 int vtfs_create(
@@ -40,91 +54,101 @@ int vtfs_create(
     struct inode* parent_inode,
     struct dentry* child_dentry,
     umode_t mode,
-    bool b
+    bool excl
 ) {
-  ino_t root = parent_inode->i_ino;
-  const char* name = child_dentry->d_name.name;
-  if (root == 100 && !strcmp(name, "test.txt")) {
-    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFREG | 0777, 101);
-    inode->i_op = &vtfs_inode_ops;
-    inode->i_fop = NULL;
-
-    d_add(child_dentry, inode);
-    mask |= 1;
-  } else if (root == 100 && !strcmp(name, "new_file.txt")) {
-    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFREG | 07777, 102);
-    inode->i_op = &vtfs_inode_ops;
-    inode->i_fop = NULL;
-
-    d_add(child_dentry, inode);
-    mask |= 2;
+  if (S_ISDIR(mode)) {
+    LOG("Directory creation is not supported yet\n");
+    return -EPERM;
   }
+
+  struct vtfs_dir* parent_dir = parent_inode->i_private;
+  struct vtfs_file* new_file;
+
+  struct list_head* pos;
+  list_for_each(pos, &parent_dir->children) {
+    struct vtfs_file* entry = list_entry(pos, struct vtfs_file, list);
+    if (strcmp(entry->name, child_dentry->d_name.name) == 0) {
+      return -EEXIST;
+    }
+  }
+
+  new_file = kmalloc(sizeof(struct vtfs_file), GFP_KERNEL);
+  if (!new_file)
+    return -ENOMEM;
+
+  new_file->name = kstrdup(child_dentry->d_name.name, GFP_KERNEL);
+  new_file->ino = get_next_ino();
+  new_file->mode = mode;
+  new_file->size = 0;
+  new_file->data = NULL;
+
+  new_file->inode = vtfs_get_inode(parent_inode->i_sb, parent_inode, mode, new_file->ino);
+  new_file->inode->i_private = NULL;
+
+  list_add(&new_file->list, &parent_dir->children);
+  d_add(child_dentry, new_file->inode);
   return 0;
 }
 
 int vtfs_unlink(struct inode* parent_inode, struct dentry* child_dentry) {
+  struct vtfs_dir* parent_dir = parent_inode->i_private;
   const char* name = child_dentry->d_name.name;
-  ino_t root = parent_inode->i_ino;
-  if (root == 100 && !strcmp(name, "test.txt")) {
-    mask &= ~1;
-  } else if (root == 100 && !strcmp(name, "new_file.txt")) {
-    mask &= ~2;
+
+  struct list_head *pos, *tmp;
+  list_for_each_safe(pos, tmp, &parent_dir->children) {
+    struct vtfs_file* entry = list_entry(pos, struct vtfs_file, list);
+    if (strcmp(entry->name, name) == 0) {
+      list_del(&entry->list);
+      d_delete(child_dentry);
+      kfree(entry->name);
+      kfree(entry->data);
+      kfree(entry);
+      return 0;
+    }
   }
-  return 0;
+  return -ENOENT;
 }
 
 int vtfs_iterate(struct file* flip, struct dir_context* ctx) {
-  struct dentry* dentry = flip->f_path.dentry;
-  struct inode* inode = dentry->d_inode;
+  struct vtfs_dir* dir = flip->f_inode->i_private;
+  struct list_head* pos;
   unsigned long offset = ctx->pos;
-  ino_t ino = inode->i_ino;
+  unsigned long index = 0;
 
-  // for now we must keep fixed list of entries
-  // standard solution involved iterating inside infinite loop with an upper condition,
-  // which when not satisfied will throw kernel into panic
-  struct {
-    const char* name;
-    unsigned char ftype;
-    ino_t ino;
-  } entries[] = {
-      {       ".", DT_DIR,                              ino},
-      {      "..", DT_DIR, dentry->d_parent->d_inode->i_ino},
-      {"test.txt", DT_REG,                              101},
-  };
+  list_for_each(pos, &dir->children) {
+    if (index++ < offset)
+      continue;
 
-  int total_entries = sizeof(entries) / sizeof(entries[0]);
-
-  if (offset >= total_entries) {
-    return 0;
-  }
-
-  for (; offset < total_entries; offset++) {
+    struct vtfs_file* entry = list_entry(pos, struct vtfs_file, list);
     if (!dir_emit(
             ctx,
-            entries[offset].name,
-            strlen(entries[offset].name),
-            entries[offset].ino,
-            entries[offset].ftype
+            entry->name,
+            strlen(entry->name),
+            entry->ino,
+            S_ISDIR(entry->mode) ? DT_DIR : DT_REG
         )) {
       return -ENOMEM;
     }
     ctx->pos++;
   }
+
   return 0;
 }
 
 struct dentry* vtfs_lookup(
     struct inode* parent_inode, struct dentry* child_dentry, unsigned int flag
 ) {
-  ino_t root = parent_inode->i_ino;
-  const char* name = child_dentry->d_name.name;
-  if (root == 100 && !strcmp(name, "test.txt")) {
-    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFREG, 101);
-    d_add(child_dentry, inode);
-  } else if (root == 100 && !strcmp(name, "dir")) {
-    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFDIR, 200);
-    d_add(child_dentry, inode);
+  struct vtfs_dir* parent_dir = parent_inode->i_private;
+
+  struct list_head* pos;
+  list_for_each(pos, &parent_dir->children) {
+    struct vtfs_file* entry = list_entry(pos, struct vtfs_file, list);
+    if (strcmp(entry->name, child_dentry->d_name.name) == 0) {
+      d_add(child_dentry, entry->inode);
+      return NULL;
+    }
   }
+
   return NULL;
 }
 struct inode* vtfs_get_inode(
@@ -141,14 +165,44 @@ struct inode* vtfs_get_inode(
 }
 
 int vtfs_fill_super(struct super_block* sb, void* data, int silent) {
-  struct inode* inode = vtfs_get_inode(sb, NULL, S_IFDIR | 0777, 100);
-  inode->i_op = &vtfs_inode_ops;
-  inode->i_fop = &vtfs_dir_ops;
-  sb->s_root = d_make_root(inode);
-  if (sb->s_root == NULL) {
+  struct vtfs_dir* root_dir;
+  struct vtfs_file* root_file;
+
+  root_dir = kmalloc(sizeof(struct vtfs_dir), GFP_KERNEL);
+  if (!root_dir) {
     return -ENOMEM;
   }
-  printk(KERN_INFO "return 0\n");
+
+  INIT_LIST_HEAD(&root_dir->children);
+
+  root_file = kmalloc(sizeof(struct vtfs_file), GFP_KERNEL);
+  if (!root_file) {
+    kfree(root_dir);
+    return -ENOMEM;
+  }
+
+  root_file->name = kstrdup("/", GFP_KERNEL);
+  root_file->ino = 100;
+  root_file->mode = S_IFDIR | 0777;
+  root_file->inode = vtfs_get_inode(sb, NULL, root_file->mode, root_file->ino);
+  root_file->data = NULL;
+  root_file->size = 0;
+
+  root_dir->self = root_file;
+
+  root_file->inode->i_private = root_dir;
+  root_file->inode->i_op = &vtfs_inode_ops;
+  root_file->inode->i_fop = &vtfs_dir_ops;
+
+  sb->s_root = d_make_root(root_file->inode);
+  if (!sb->s_root) {
+    kfree(root_file->name);
+    kfree(root_file);
+    kfree(root_dir);
+    return -ENOMEM;
+  }
+
+  LOG("Superblock initialized");
   return 0;
 }
 

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -19,7 +19,62 @@ void vtfs_kill_sb(struct super_block*);
 struct dentry* vtfs_mount(struct file_system_type*, int, const char*, void*);
 int vtfs_fill_super(struct super_block*, void*, int);
 struct inode* vtfs_get_inode(struct super_block*, const struct inode*, umode_t, int);
+struct dentry* vtfs_lookup(struct inode*, struct dentry*, unsigned int);
+int vtfs_iterate(struct file*, struct dir_context*);
 
+struct file_operations vtfs_dir_ops = {
+    .iterate_shared = vtfs_iterate,
+};
+
+int vtfs_iterate(struct file* flip, struct dir_context* ctx) {
+  struct dentry* dentry = flip->f_path.dentry;
+  struct inode* inode = dentry->d_inode;
+  unsigned long offset = ctx->pos;
+  ino_t ino = inode->i_ino;
+
+  // for now we must keep fixed list of entries
+  // standard solution involved iterating inside infinite loop with an upper condition,
+  // which when not satisfied will throw kernel into panic
+  struct {
+    const char* name;
+    unsigned char ftype;
+    ino_t ino;
+  } entries[] = {
+      {       ".", DT_DIR,                              ino},
+      {      "..", DT_DIR, dentry->d_parent->d_inode->i_ino},
+      {"test.txt", DT_REG,                              101},
+  };
+
+  int total_entries = sizeof(entries) / sizeof(entries[0]);
+
+  if (offset >= total_entries) {
+    return 0;
+  }
+
+  for (; offset < total_entries; offset++) {
+    if (!dir_emit(
+            ctx,
+            entries[offset].name,
+            strlen(entries[offset].name),
+            entries[offset].ino,
+            entries[offset].ftype
+        )) {
+      return -ENOMEM;
+    }
+    ctx->pos++;
+  }
+  return 0;
+}
+
+struct inode_operations vtfs_inode_ops = {
+    .lookup = vtfs_lookup,
+};
+
+struct dentry* vtfs_lookup(
+    struct inode* parent_inode, struct dentry* child_dentry, unsigned int flag
+) {
+  return NULL;
+}
 struct inode* vtfs_get_inode(
     struct super_block* sb, const struct inode* dir, umode_t mode, int i_ino
 ) {
@@ -27,13 +82,16 @@ struct inode* vtfs_get_inode(
   struct mnt_idmap* idmap = &nop_mnt_idmap;
   if (inode != NULL) {
     inode_init_owner(idmap, inode, dir, mode);
+    inode->i_mode = mode;
   }
   inode->i_ino = i_ino;
   return inode;
 }
 
 int vtfs_fill_super(struct super_block* sb, void* data, int silent) {
-  struct inode* inode = vtfs_get_inode(sb, NULL, S_IFDIR, 1000);
+  struct inode* inode = vtfs_get_inode(sb, NULL, S_IFDIR | 0777, 100);
+  inode->i_op = &vtfs_inode_ops;
+  inode->i_fop = &vtfs_dir_ops;
   sb->s_root = d_make_root(inode);
   if (sb->s_root == NULL) {
     return -ENOMEM;

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -73,8 +73,19 @@ struct inode_operations vtfs_inode_ops = {
 struct dentry* vtfs_lookup(
     struct inode* parent_inode, struct dentry* child_dentry, unsigned int flag
 ) {
+  ino_t root = parent_inode->i_ino;
+  const char* name = child_dentry->d_name.name;
+  if (root == 100 && !strcmp(name, "test.txt")) {
+    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFREG, 101);
+    d_add(child_dentry, inode);
+    // this here is useless for now
+  } else if (root == 100 && !strcmp(name, "dir")) {
+    struct inode* inode = vtfs_get_inode(parent_inode->i_sb, NULL, S_IFDIR, 200);
+    d_add(child_dentry, inode);
+  }
   return NULL;
 }
+
 struct inode* vtfs_get_inode(
     struct super_block* sb, const struct inode* dir, umode_t mode, int i_ino
 ) {

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -25,6 +25,9 @@ struct inode* vtfs_get_inode(
 ) {
   struct inode* inode = new_inode(sb);
   if (inode != NULL) {
+    // in linux kernel v6.8.0, inode_init_owner() call takes struct mnt_idmap* as first argument
+    // instead of usual user_namespace*, and i do not have any way to access this structure this
+    // here is a basic replacement of inode_init_owner() call
     inode->i_mode = mode;
     i_uid_write(inode, 0);
     i_gid_write(inode, 0);

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -1,6 +1,11 @@
+#include <linux/fs.h>
 #include <linux/init.h>
+#include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/printk.h>
+#include <linux/processor.h>
+#include <linux/slab.h>
+#include <linux/string.h>
 
 #define MODULE_NAME "vtfs"
 
@@ -10,12 +15,66 @@ MODULE_DESCRIPTION("A simple FS kernel module");
 
 #define LOG(fmt, ...) pr_info("[" MODULE_NAME "]: " fmt, ##__VA_ARGS__)
 
+void vtfs_kill_sb(struct super_block*);
+struct dentry* vtfs_mount(struct file_system_type*, int, const char*, void*);
+int vtfs_fill_super(struct super_block*, void*, int);
+struct inode* vtfs_get_inode(struct super_block*, const struct inode*, umode_t, int);
+
+struct inode* vtfs_get_inode(
+    struct super_block* sb, const struct inode* dir, umode_t mode, int i_ino
+) {
+  struct inode* inode = new_inode(sb);
+  if (inode != NULL) {
+    inode->i_mode = mode;
+    i_uid_write(inode, 0);
+    i_gid_write(inode, 0);
+    inode->__i_atime = inode->__i_mtime = inode->__i_ctime = current_time(inode);
+  }
+
+  inode->i_ino = i_ino;
+  return inode;
+}
+
+int vtfs_fill_super(struct super_block* sb, void* data, int silent) {
+  struct inode* inode = vtfs_get_inode(sb, NULL, S_IFDIR, 1000);
+  sb->s_root = d_make_root(inode);
+  if (sb->s_root == NULL) {
+    return -ENOMEM;
+  }
+  printk(KERN_INFO "return 0\n");
+  return 0;
+}
+
+void vtfs_kill_sb(struct super_block* sb) {
+  printk(KERN_INFO "vtfs super block is destroyed. Unmount successfully.\n");
+}
+
+struct file_system_type vtfs_fs_type = {
+    .name = "vtfs",
+    .mount = vtfs_mount,
+    .kill_sb = vtfs_kill_sb,
+};
+
+struct dentry* vtfs_mount(
+    struct file_system_type* fs_type, int flags, const char* token, void* data
+) {
+  struct dentry* ret = mount_nodev(fs_type, flags, data, vtfs_fill_super);
+  if (ret == NULL) {
+    printk(KERN_ERR "Can't mount file system");
+  } else {
+    printk(KERN_INFO "Mounted successfully");
+  }
+  return ret;
+}
+
 static int __init vtfs_init(void) {
+  register_filesystem(&vtfs_fs_type);
   LOG("VTFS joined the kernel\n");
   return 0;
 }
 
 static void __exit vtfs_exit(void) {
+  unregister_filesystem(&vtfs_fs_type);
   LOG("VTFS left the kernel\n");
 }
 

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -1,4 +1,3 @@
-
 #include <linux/fs.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
@@ -41,10 +40,18 @@ int vtfs_create(struct mnt_idmap*, struct inode*, struct dentry*, umode_t, bool)
 int vtfs_unlink(struct inode*, struct dentry*);
 int vtfs_mkdir(struct mnt_idmap*, struct inode*, struct dentry*, umode_t);
 int vtfs_rmdir(struct inode*, struct dentry*);
+ssize_t vtfs_read(struct file*, char __user*, size_t, loff_t*);
+ssize_t vtfs_write(struct file*, const char __user*, size_t, loff_t*);
 int vtfs_link(struct dentry*, struct inode*, struct dentry*);
 
 struct file_operations vtfs_dir_ops = {
     .iterate_shared = vtfs_iterate,
+};
+
+struct file_operations vtfs_file_ops = {
+    .read = vtfs_read,
+    .write = vtfs_write,
+    .llseek = generic_file_llseek,
 };
 
 struct inode_operations vtfs_inode_ops = {

--- a/lab/vtfs/source/vtfs.c
+++ b/lab/vtfs/source/vtfs.c
@@ -24,16 +24,10 @@ struct inode* vtfs_get_inode(
     struct super_block* sb, const struct inode* dir, umode_t mode, int i_ino
 ) {
   struct inode* inode = new_inode(sb);
+  struct mnt_idmap* idmap = &nop_mnt_idmap;
   if (inode != NULL) {
-    // in linux kernel v6.8.0, inode_init_owner() call takes struct mnt_idmap* as first argument
-    // instead of usual user_namespace*, and i do not have any way to access this structure this
-    // here is a basic replacement of inode_init_owner() call
-    inode->i_mode = mode;
-    i_uid_write(inode, 0);
-    i_gid_write(inode, 0);
-    inode->__i_atime = inode->__i_mtime = inode->__i_ctime = current_time(inode);
+    inode_init_owner(idmap, inode, dir, mode);
   }
-
   inode->i_ino = i_ino;
   return inode;
 }

--- a/vtfs/.gitattributes
+++ b/vtfs/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/vtfs/.gitignore
+++ b/vtfs/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/vtfs/.mvn/wrapper/maven-wrapper.properties
+++ b/vtfs/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/vtfs/mvnw
+++ b/vtfs/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/vtfs/mvnw.cmd
+++ b/vtfs/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/vtfs/pom.xml
+++ b/vtfs/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.2</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>itmo.localpiper</groupId>
+	<artifactId>vtfs</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>war</packaging>
+	<name>vtfs</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/vtfs/pom.xml
+++ b/vtfs/pom.xml
@@ -33,9 +33,27 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.jpa</artifactId>
+			<version>2.7.11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.core</artifactId>
+			<version>2.7.11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
@@ -45,6 +63,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.4</version>
 		</dependency>
 	</dependencies>
 

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadata.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadata.java
@@ -1,0 +1,24 @@
+package itmo.localpiper.vtfs;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FileMetadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String fileName;
+    private long inode;
+    private int linkCount;
+}

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataController.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataController.java
@@ -1,0 +1,37 @@
+package itmo.localpiper.vtfs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileMetadataController {
+
+    @Autowired
+    private FileMetadataService fileService;
+
+    @PostMapping("/create")
+    public ResponseEntity<FileMetadata> createFile(@RequestParam String fileName) {
+        FileMetadata file = fileService.createFile(fileName);
+        return new ResponseEntity<>(file, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/link")
+    public ResponseEntity<FileMetadata> linkFile(@RequestParam String oldFileName, @RequestParam String newFileName) {
+        FileMetadata file = fileService.linkFile(oldFileName, newFileName);
+        return new ResponseEntity<>(file, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteFile(@RequestParam String fileName) {
+        fileService.deleteFile(fileName);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}
+

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataRepository.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataRepository.java
@@ -1,0 +1,10 @@
+package itmo.localpiper.vtfs;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
+    Optional<FileMetadata> findByFileName(String fileName);
+    Optional<FileMetadata> findByInode(long inode);
+}

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataService.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/FileMetadataService.java
@@ -1,0 +1,52 @@
+package itmo.localpiper.vtfs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FileMetadataService {
+
+    @Autowired
+    private FileMetadataRepository fileMetadataRepository;
+
+    public FileMetadata createFile(String fileName) {
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setFileName(fileName);
+        fileMetadata.setInode(generateInode());
+        fileMetadata.setLinkCount(1);
+        return fileMetadataRepository.save(fileMetadata);
+    }
+
+    public FileMetadata linkFile(String oldFileName, String newFileName) {
+        FileMetadata oldFile = fileMetadataRepository.findByFileName(oldFileName)
+                .orElseThrow(() -> new RuntimeException("File not found"));
+        FileMetadata newFile = new FileMetadata();
+        newFile.setFileName(newFileName);
+        newFile.setInode(oldFile.getInode());
+        newFile.setLinkCount(oldFile.getLinkCount() + 1);
+        
+        fileMetadataRepository.save(newFile);
+        
+        oldFile.setLinkCount(oldFile.getLinkCount() + 1);
+        fileMetadataRepository.save(oldFile);
+        
+        return newFile;
+    }
+
+    public void deleteFile(String fileName) {
+        FileMetadata file = fileMetadataRepository.findByFileName(fileName)
+                .orElseThrow(() -> new RuntimeException("File not found"));
+
+        if (file.getLinkCount() > 1) {
+            file.setLinkCount(file.getLinkCount() - 1);
+            fileMetadataRepository.save(file);
+        } else {
+            fileMetadataRepository.delete(file);
+        }
+    }
+
+    private long generateInode() {
+        return System.currentTimeMillis();
+    }
+}
+

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/ServletInitializer.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/ServletInitializer.java
@@ -1,0 +1,13 @@
+package itmo.localpiper.vtfs;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+public class ServletInitializer extends SpringBootServletInitializer {
+
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+		return application.sources(VtfsApplication.class);
+	}
+
+}

--- a/vtfs/src/main/java/itmo/localpiper/vtfs/VtfsApplication.java
+++ b/vtfs/src/main/java/itmo/localpiper/vtfs/VtfsApplication.java
@@ -1,0 +1,13 @@
+package itmo.localpiper.vtfs;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class VtfsApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(VtfsApplication.class, args);
+	}
+
+}

--- a/vtfs/src/main/resources/application.properties
+++ b/vtfs/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=vtfs

--- a/vtfs/src/test/java/itmo/localpiper/vtfs/VtfsApplicationTests.java
+++ b/vtfs/src/test/java/itmo/localpiper/vtfs/VtfsApplicationTests.java
@@ -1,0 +1,13 @@
+package itmo.localpiper.vtfs;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class VtfsApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
P3306 Сорокин Артём Николаевич
Продвинутый трек, оценка 4 (я 5 уже не смогу получить). ЛР 4.1 Файловая система в Linux
Вариант: Linux

## Описание изменений

Реализовал модуль файловой системы VTFS для Linux (дистрибутив Ubuntu, версия ядра 6.8), включающий следующие возможности:
- создание файлов (touch)
- удаление файлов (rm)
- создание директорий (mkdir)
- удаление директорий (rmdir)
- просмотр содержимого директорий (ls)
- чтение из файла (cat)
- запись в файл (echo)
- создание жесткой ссылки на файл (ln)

Дополнительно создал бекенд на базе Spring и PostgreSQL (пока не линковал с http.c, сделаю в будущем если успею)

## Про разработку под версию ядра 6.8

На самом деле, отличий не так много, но они могут быть неприятными.

### Часть 2. Подготовка файловой системы

Рассмотрим предложенную реализацию функции `vtfs_get_inode`:
 ```c
struct inode* vtfs_get_inode(
    struct super_block* sb,
    const struct inode* dir,
    umode_t mode,
    int i_ino
) {
    struct inode *inode = new_inode(sb);
    if (inode != NULL) {
        inode_init_owner(inode, dir, mode);
    }
    inode->i_ino = i_ino;
    return inode;
}
```
Возможно, в более старых версиях ядра функция `inode_init_owner` принимала 3 аргумента, но в версии 6.8 она принимает 4 - первым аргументом является структура `mnt_idmap`:
```c
void inode_init_owner(struct mnt_idmap *idmap, struct inode *inode,
		      const struct inode *dir, umode_t mode);
```

(обращу внимание, что в задании есть ссылка на описание `inode_init_owner` в версии 5.15.53, где она так же имеет 4 аргумента, а не 3)

Данную структуру нельзя извлечь из передаваемых в функцию аргументов (по крайней мере, я не нашел способ), но ее можно заменить заглушкой `&nop_mnt_idmap`

### Часть 3. Вывод файлов и директорий

Вот тут:
```c
struct file_operations vtfs_dir_ops = {
    .iterate = vtfs_iterate,
};
```

Емнип начиная с версии 5.12 поле `.iterate` теперь называется `.iterate_shared`

### Часть 5. Создание и удаление файлов

Было:
```c
int (*create) (struct inode*, struct dentry*, umode_t, bool);
```
Стало:
```c
int (*create) (struct mnt_idmap*, struct inode*, struct dentry*, umode_t, bool);
```

### Часть 7. Создание и удаление директорий
Та же ситуация, что и на прошлом этапе

Это все, что я обнаружил